### PR TITLE
Add a Lua pattern for biblatex-apa.

### DIFF
--- a/tdsutil/recipes/biblatex-apa.ini
+++ b/tdsutil/recipes/biblatex-apa.ini
@@ -1,0 +1,2 @@
+[patterns]
+  tex[]=*.lua


### PR DESCRIPTION
Hi,
I am not quite sure if this is all that's needed. I took biblatex-ext as an example, since it has a similar file tree structure and also includes a .lua file.

If that fixes it, this should close #336.