### PR TITLE
adjust rwth-ci recipe to match the new bundle structure

### DIFF
--- a/tdsutil/recipes/rwth-ci.ini
+++ b/tdsutil/recipes/rwth-ci.ini
@@ -1,5 +1,8 @@
+[ins]
+  engine=pdflatex
+  options[]=--include-directory=tex
+
 [patterns]
-  doc[]=doc/*.pdf
-  doc[]=examples
+  doc[]=doc/*
   tex[]=tex/*
-  
+  ins[]=source/*.ins


### PR DESCRIPTION
I modified the structure of the rwth-ci package to integrate easier into TeX Live. I am not quite sure if MikTeX matches these defaults … but I now adjusted the recipe to match the pattern I found within others. 

So it should be working again that way.

In case it makes any difference concerning the workload I will upload another update to CTAN today.  So maybe it's better to wait until tht one is synced. 

Thanks!

And a slighlty off-topic question concerning the unpacking: Is the unpacking done locally or before that?
Since pdflatex is no pure UTF-8 I thought about switching to lualatex for unpacking, but I wondered if this would require the engine to be installed. Just wondering.